### PR TITLE
Ensure that manpage is populated

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,13 +2,15 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.12"
+    os: ubuntu-22.04
+    tools:
+        python: "3.12"
 
 sphinx:
-  configuration: docs/conf.py
+    configuration: docs/conf.py
 
 python:
-  install:
-    - requirements: docs/requirements.txt
+    install:
+        -   requirements: docs/requirements.txt
+        -   method: pip
+            path: .


### PR DESCRIPTION
This change was tested on my instance at https://mab879-compliance-tool.readthedocs.io/en/latest/compliance-tool.1.html.

This fixes the issue with page being blank.